### PR TITLE
Refactor/search

### DIFF
--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/api/search/SearchController.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/api/search/SearchController.java
@@ -2,7 +2,7 @@ package com.gitsunjaeab.mapick.api.search;
 
 import com.gitsunjaeab.mapick.api.search.dto.SearchHistoryDTO;
 import com.gitsunjaeab.mapick.api.search.dto.request.SearchRequest;
-import com.gitsunjaeab.mapick.api.search.dto.response.SearchListResponse;
+import com.gitsunjaeab.mapick.api.search.dto.response.SearchResponse;
 import com.gitsunjaeab.mapick.application.search.SearchHistoryService;
 import com.gitsunjaeab.mapick.application.search.SearchService;
 import com.gitsunjaeab.mapick.domain.auth.Principal;
@@ -13,9 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -42,14 +40,14 @@ public class SearchController {
     @GetMapping("/list")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 목록 조회", description = "최신 검색 목록 조회" )
-    public ResponseEntity<SearchListResponse> getSearchHistories(
+    public ResponseEntity<SearchResponse> getSearchHistories(
             @AuthenticationPrincipal Principal principal) {
 
         Long memberId = principal.getMember().getId();
 
         List<SearchHistoryDTO> searchHistoryDTOs = searchHistoryService.getSearchHistories(memberId);
 
-        SearchListResponse response = SearchListResponse.get(searchHistoryDTOs);
+        SearchResponse response = SearchResponse.getList(searchHistoryDTOs);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -61,7 +59,7 @@ public class SearchController {
     @PostMapping
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 목록 저장", description = "최신 검색 목록 저장" )
-    public ResponseEntity<SearchListResponse> saveSearchHistory(
+    public ResponseEntity<SearchResponse> saveSearchHistory(
             @AuthenticationPrincipal Principal principal,
             @RequestBody SearchRequest searchRequest) {
 
@@ -69,7 +67,7 @@ public class SearchController {
 
         searchHistoryService.saveSearchHistory(memberId,searchRequest);
 
-        SearchListResponse response = SearchListResponse.save();
+        SearchResponse response = SearchResponse.save();
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -81,7 +79,7 @@ public class SearchController {
     @DeleteMapping
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 항목 단일 삭제", description = "최신 검색 항목 단일 삭제" )
-    public ResponseEntity<SearchListResponse> deletSearchHistory(
+    public ResponseEntity<SearchResponse> deletSearchHistory(
             @AuthenticationPrincipal Principal principal,
             @RequestParam("keyword") String keyword) {
 
@@ -89,7 +87,7 @@ public class SearchController {
 
         searchHistoryService.deleteSearchHistory(memberId,keyword);
 
-        SearchListResponse response = SearchListResponse.remove();
+        SearchResponse response = SearchResponse.remove();
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -102,14 +100,14 @@ public class SearchController {
     @DeleteMapping("/list")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 목록 삭제", description = "최신 검색 목록 삭제" )
-    public ResponseEntity<SearchListResponse> deletSearchHistoryList(
+    public ResponseEntity<SearchResponse> deletSearchHistoryList(
             @AuthenticationPrincipal Principal principal) {
 
         Long memberId = principal.getMember().getId();
 
         searchHistoryService.deleteSearchHistoryList(memberId);
 
-        SearchListResponse response = SearchListResponse.removeList();
+        SearchResponse response = SearchResponse.removeList();
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/api/search/SearchController.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/api/search/SearchController.java
@@ -5,6 +5,7 @@ import com.gitsunjaeab.mapick.api.search.dto.request.SearchRequest;
 import com.gitsunjaeab.mapick.api.search.dto.response.SearchListResponse;
 import com.gitsunjaeab.mapick.application.search.SearchHistoryService;
 import com.gitsunjaeab.mapick.application.search.SearchService;
+import com.gitsunjaeab.mapick.domain.auth.Principal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,12 +29,12 @@ public class SearchController {
     private final SearchService searchService;
     private final SearchHistoryService searchHistoryService;
 
-    @GetMapping
-    public ResponseEntity<SearchListResponse> search(@RequestParam("keyword") String keyword) {
-        SearchListResponse resultResponse = searchService.search(keyword);
-
-        return ResponseEntity.ok(resultResponse);
-    }
+//    @GetMapping
+//    public ResponseEntity<SearchListResponse> search(@RequestParam("keyword") String keyword) {
+//        SearchListResponse resultResponse = searchService.search(keyword);
+//
+//        return ResponseEntity.ok(resultResponse);
+//    }
 
 
     // 최신 검색 목록 조회
@@ -40,10 +42,10 @@ public class SearchController {
     @GetMapping("/list")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 목록 조회", description = "최신 검색 목록 조회" )
-    public ResponseEntity<SearchListResponse> getSearchHistories() {
+    public ResponseEntity<SearchListResponse> getSearchHistories(
+            @AuthenticationPrincipal Principal principal) {
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long memberId = Long.parseLong(auth.getName());
+        Long memberId = principal.getMember().getId();
 
         List<SearchHistoryDTO> searchHistoryDTOs = searchHistoryService.getSearchHistories(memberId);
 
@@ -59,10 +61,11 @@ public class SearchController {
     @PostMapping
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 목록 저장", description = "최신 검색 목록 저장" )
-    public ResponseEntity<SearchListResponse> saveSearchHistory(@RequestBody SearchRequest searchRequest) {
+    public ResponseEntity<SearchListResponse> saveSearchHistory(
+            @AuthenticationPrincipal Principal principal,
+            @RequestBody SearchRequest searchRequest) {
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long memberId = Long.parseLong(auth.getName());
+        Long memberId = principal.getMember().getId();
 
         searchHistoryService.saveSearchHistory(memberId,searchRequest);
 
@@ -78,10 +81,11 @@ public class SearchController {
     @DeleteMapping
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 항목 단일 삭제", description = "최신 검색 항목 단일 삭제" )
-    public ResponseEntity<SearchListResponse> deletSearchHistory(@RequestParam("keyword") String keyword) {
+    public ResponseEntity<SearchListResponse> deletSearchHistory(
+            @AuthenticationPrincipal Principal principal,
+            @RequestParam("keyword") String keyword) {
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long memberId = Long.parseLong(auth.getName());
+        Long memberId = principal.getMember().getId();
 
         searchHistoryService.deleteSearchHistory(memberId,keyword);
 
@@ -98,10 +102,10 @@ public class SearchController {
     @DeleteMapping("/list")
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @Operation(summary = "최신 검색 목록 삭제", description = "최신 검색 목록 삭제" )
-    public ResponseEntity<SearchListResponse> deletSearchHistoryList() {
+    public ResponseEntity<SearchListResponse> deletSearchHistoryList(
+            @AuthenticationPrincipal Principal principal) {
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long memberId = Long.parseLong(auth.getName());
+        Long memberId = principal.getMember().getId();
 
         searchHistoryService.deleteSearchHistoryList(memberId);
 

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/api/search/dto/response/SearchResponse.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/api/search/dto/response/SearchResponse.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class SearchListResponse implements BaseApiResponse {
+public class SearchResponse implements BaseApiResponse {
 
     private String code;
     private String message;
@@ -24,8 +24,8 @@ public class SearchListResponse implements BaseApiResponse {
 
 
 
-    public static SearchListResponse get(List<SearchHistoryDTO> SearchHistoryDTOs) {
-        return new SearchListResponse(
+    public static SearchResponse getList(List<SearchHistoryDTO> SearchHistoryDTOs) {
+        return new SearchResponse(
                 ResponseCode.OK.getCode(),
                 "최근 검색어 목록 조회 완료",
                 OffsetDateTime.now(),
@@ -33,8 +33,8 @@ public class SearchListResponse implements BaseApiResponse {
         );
     }
 
-    public static SearchListResponse save() {
-        return new SearchListResponse(
+    public static SearchResponse save() {
+        return new SearchResponse(
                 ResponseCode.OK.getCode(),
                 "최근 검색어 저장 완료",
                 OffsetDateTime.now(),
@@ -42,8 +42,8 @@ public class SearchListResponse implements BaseApiResponse {
         );
     }
 
-    public static SearchListResponse remove() {
-        return new SearchListResponse(
+    public static SearchResponse remove() {
+        return new SearchResponse(
                 ResponseCode.OK.getCode(),
                 "최근 검색어 삭제 완료",
                 OffsetDateTime.now(),
@@ -51,8 +51,8 @@ public class SearchListResponse implements BaseApiResponse {
         );
     }
 
-    public static SearchListResponse removeList() {
-        return new SearchListResponse(
+    public static SearchResponse removeList() {
+        return new SearchResponse(
                 ResponseCode.OK.getCode(),
                 "최근 검색어 목록 삭제 완료",
                 OffsetDateTime.now(),

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
@@ -25,6 +25,7 @@ public class SearchHistoryService {
     private final MemberRepository memberRepository;
 
     // 최근 검색어 목록 조회
+    // complete
     public List<SearchHistoryDTO> getSearchHistories(Long memberId) {
 
         final List<Search> searches = searchRepository.findAllByMemberIdAndDeletedAtIsNull(memberId);

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
@@ -40,6 +40,7 @@ public class SearchHistoryService {
     }
 
     // 최근 검색어 저장
+    // complete
     @Transactional
     public void saveSearchHistory(Long memberId,SearchRequest searchRequest) {
 
@@ -81,7 +82,8 @@ public class SearchHistoryService {
     @Transactional
     public void deleteSearchHistory(Long memberId,String keyword) {
 
-        Search search = searchRepository.findByMemberIdAndKeywordIs(memberId,keyword);
+        Search search = searchRepository.findByMemberIdAndKeywordIs(memberId,keyword)
+                .orElseThrow(() -> new CommonException(ResponseCode.SEARCH_NOT_FOUND));
 
         search.setDeletedAt(OffsetDateTime.now());
     }

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
@@ -79,6 +79,7 @@ public class SearchHistoryService {
 
 
     // 최근 검색어 삭제
+    // complete
     @Transactional
     public void deleteSearchHistory(Long memberId,String keyword) {
 
@@ -89,6 +90,7 @@ public class SearchHistoryService {
     }
 
     // 최근 검색어 목록 삭제
+    // complete
     @Transactional
     public void deleteSearchHistoryList(Long memberId) {
 

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchHistoryService.java
@@ -10,11 +10,13 @@ import com.gitsunjaeab.mapick.domain.search.SearchRepository;
 import com.gitsunjaeab.mapick.infra.error.exceptions.CommonException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -44,19 +46,33 @@ public class SearchHistoryService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CommonException(ResponseCode.MEMBER_NOT_FOUND));
 
-        Search search = searchRepository.findByMemberIdAndKeywordIs(memberId,searchRequest.getKeyword());
+        Optional<Search> optionalSearch = searchRepository.findByMemberIdAndKeywordIs(memberId,searchRequest.getKeyword());
 
-        if(search==null){
-            Search newsearch = Search.builder()
+        if(optionalSearch.isEmpty()){ // 결과가 없는 경우
+
+            Search search = Search.builder()
                     .keyword(searchRequest.getKeyword())
                     .member(member)
                     .build();
 
-            searchRepository.save(newsearch);
-        } else if (search.getDeletedAt() != null) {
-            search.setDeletedAt(null);
-        } else {
-            search.setUpdatedAt(OffsetDateTime.now());
+            try {
+                searchRepository.save(search);
+            } catch (DataIntegrityViolationException e) {
+                throw new CommonException(ResponseCode.SAVE_FAILED);
+            }
+
+        } else{ // 결과가 있는 경우
+
+            Search search = optionalSearch.get();
+
+            if(search.getDeletedAt() != null){ // 지워졌던 결과 라면
+                search.setDeletedAt(null);
+                search.setUpdatedAt(OffsetDateTime.now());
+            }
+            else{ // 존재하는 결과라면
+
+                search.setUpdatedAt(OffsetDateTime.now());
+            }
         }
     }
 

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchService.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/application/search/SearchService.java
@@ -1,13 +1,12 @@
 package com.gitsunjaeab.mapick.application.search;
 
-import com.gitsunjaeab.mapick.api.search.dto.response.SearchListResponse;
-import lombok.AllArgsConstructor;
+import com.gitsunjaeab.mapick.api.search.dto.response.SearchResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SearchService {
 
-    public SearchListResponse search(String keyword) {
+    public SearchResponse search(String keyword) {
         return null;
     }
 }

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/common/response/ResponseCode.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/common/response/ResponseCode.java
@@ -38,6 +38,7 @@ public enum ResponseCode {
     REPORTER_NOT_FOUND("4044", HttpStatus.NOT_FOUND, "존재하지 않는 신고자 입니다."),
     MARKER_NOT_FOUND("4044", HttpStatus.NOT_FOUND, "존재하지 않는 마커 입니다."),
     QUEST_NOT_FOUND("4044", HttpStatus.NOT_FOUND, "존재하지 않는 퀘스트 입니다."),
+    SEARCH_NOT_FOUND("4044", HttpStatus.NOT_FOUND, "존재하지 않는 검색결과 입니다."),
 
 
 

--- a/MAPICK/src/main/java/com/gitsunjaeab/mapick/domain/search/SearchRepository.java
+++ b/MAPICK/src/main/java/com/gitsunjaeab/mapick/domain/search/SearchRepository.java
@@ -3,13 +3,14 @@ package com.gitsunjaeab.mapick.domain.search;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
     List<Search> findAllByMemberIdAndDeletedAtIsNull(Long memberId);
 
-    Search findByMemberIdAndKeywordIs(Long memberId, String keyword);
+    Optional<Search> findByMemberIdAndKeywordIs(Long memberId, String keyword);
 
     Search findByMemberIdAndDeletedAtIsNull(Long memberId);
 }


### PR DESCRIPTION
Summary  
- 최근 검색어 저장, 단건 조회, 전체 조회, 단건 삭제, 전체 삭제 기능 구현  
- soft delete(deletedAt) 방식 적용  

변경 사항  
- 검색어 저장 시 기존 존재 여부에 따라 새로 저장, 복구, 수정 처리  
- 단건/전체 삭제 시 deletedAt 갱신 처리  
- 예외 처리 추가  
  - 존재하지 않는 회원 또는 검색어에 대한 예외 처리 (CommonException)  
  - 저장 실패 시 DataIntegrityViolationException 처리  
- 인증된 사용자만 접근 가능하도록 구성 (@AuthenticationPrincipal 기반)  

추가된 ResponseCode  
- MEMBER_NOT_FOUND  
- SEARCH_NOT_FOUND  
- SAVE_FAILED  

기타  
- 모든 기능 트랜잭션 처리 적용  
- Optional을 활용한 null-safe 처리 방식 유지
